### PR TITLE
Add abbreviation-tag and title to responsibility filters

### DIFF
--- a/_includes/filters-responsibility.hbs
+++ b/_includes/filters-responsibility.hbs
@@ -36,7 +36,8 @@
       type="radio"
       value="dev">
 
-    <span class="label label-dev">Dev</span>
+    <abbr title="General Development"
+          class="label label-dev">Dev</abbr>
   </label>
   <label>
     <input
@@ -45,7 +46,8 @@
       type="radio"
       value="fed">
 
-    <span class="label label-fed">FED</span>
+    <abbr title="Front-End Development"
+          class="label label-fed">FED</abbr>
   </label>
   <label>
     <input
@@ -54,6 +56,7 @@
       type="radio"
       value="ux">
 
-    <span class="label label-ux">UX</span>
+    <abbr title="User Experience"
+          class="label label-ux">UX</abbr>
   </label>
 </fieldset>


### PR DESCRIPTION
Since "Dev", "FED" and "UX" are abbreviations, add a `<abbr/>` and title-attribute. At least "FED" is not very common, among non-devs.
